### PR TITLE
Show errors from commit failure

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -211,8 +211,8 @@ class VyOSDriver(NetworkDriver):
 
         try:
             self.device.commit()
-        except ValueError:
-            raise CommitError("Failed to commit config on the device")
+        except ValueError as err:
+            raise CommitError('\n\n{}'.format(err))
 
         self.device.send_config_set(['save'])
         self.device.exit_config_mode()


### PR DESCRIPTION
Fixes #47 

Capture the errors from Netmiko and show them to the user

Before:

```
TASK [Apply Configuration] **********************************************
fatal: [dev]: FAILED! => changed=false 
  msg: 'cannot install config: Failed to commit config on the device'
```

After:

```
TASK [Apply Configuration] ************************************************
fatal: [dev]: FAILED! => changed=false 
  msg: |-
    cannot install config:
  
    Commit failed with following errors:
  
    commit
    [ interfaces l2tpv3 l2tpeth1 address 192.168.1/30 ]
    Error: 192.168.1/30 is not a valid IP host
  
  
  
    [ interfaces l2tpv3 l2tpeth1 address 192.168.1/30 ]
    Invalid value
  
    [[interfaces l2tpv3 l2tpeth1]] failed
    Commit failed
    [edit]

```
