### PR TITLE
Give the ability to use the SSH Agent

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -73,6 +73,7 @@ class VyOSDriver(NetworkDriver):
             'alt_host_keys': False,
             'alt_key_file': '',
             'ssh_config_file': None,
+            'allow_agent': False,
         }
 
         fields = netmiko_version.split('.')


### PR DESCRIPTION
This way the module can be configured to use the ssh agent, like that:
```yaml
- name: install config
  napalm.napalm.napalm_install_config:
    [...]
    optional_args:
      allow_agent: true
```